### PR TITLE
fix(google-authenticate): add .env CLIENT_URL 🔨

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -19,7 +19,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 app.use(cors({
-    origin: 'http://localhost:3000',
+    origin: process.env.CLIENT_URL,
     methods: 'GET, POST, PUT, DELETE',
     credentials: true
 }));

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -2,7 +2,7 @@ const router = require("express").Router();
 const passport = require("passport");
 const userValidation = require("../controllers/userValidation");
 
-const CLIENT_URL = "http://localhost:3000/";
+const CLIENT_URL = process.env.CLIENT_URL;
 
 router.get("/login/success", async (req, res) => {
   if (req.user) {


### PR DESCRIPTION
Por favor al .env del backend agreguen una variable más de la siguiente manera:
CLIENT_URL = http://localhost:3000

🔻🔻🔻Si no se agrega la variable las funcionalidades de GOOGLE no funcionará ni el local y el producción.